### PR TITLE
Rearranged Dockerfile to dockerfile style

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 # Pull base image.
 FROM dockerfile/ubuntu
 
-ADD mysql_bootstrap.sh
+ADD mysql_bootstrap.sh /tmp/mysql_bootstrap.sh
 
 RUN apt-key adv --keyserver keys.gnupg.net --recv-keys 1C4CBDCDCD2EFD2A && \
     echo "deb http://repo.percona.com/apt `lsb_release -cs` main" > /etc/apt/sources.list.d/percona.list && \
@@ -17,8 +17,8 @@ RUN apt-key adv --keyserver keys.gnupg.net --recv-keys 1C4CBDCDCD2EFD2A && \
     rm -rf /var/lib/apt/lists/* && \
     sed -i 's/^\(bind-address\s.*\)/# \1/' /etc/mysql/my.cnf && \
     sed -i 's/^\(log_error\s.*\)/# \1/' /etc/mysql/my.cnf && \
-    bash mysql_bootstrap.sh && \
-    rm -f mysql_bootstrap.sh
+    bash /tmp/mysql_bootstrap.sh && \
+    rm -f /tmp/mysql_bootstrap.sh
 
 # Define mountable directories.
 VOLUME ["/data", "/etc/mysql", "/var/lib/mysql"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-key adv --keyserver keys.gnupg.net --recv-keys 1C4CBDCDCD2EFD2A && \
     echo "deb http://repo.percona.com/apt `lsb_release -cs` main" > /etc/apt/sources.list.d/percona.list && \
     echo "deb-src http://repo.percona.com/apt `lsb_release -cs` main" >> /etc/apt/sources.list.d/percona.list && \
     apt-get update -qq && \
-    apt-get install -y -qq percona-server-5.6 && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq percona-server-5.6 && \
     rm -rf /var/lib/apt/lists/* && \
     sed -i 's/^\(bind-address\s.*\)/# \1/' /etc/mysql/my.cnf && \
     sed -i 's/^\(log_error\s.*\)/# \1/' /etc/mysql/my.cnf && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,34 +7,18 @@
 # Pull base image.
 FROM dockerfile/ubuntu
 
-MAINTAINER Marcus Bointon <marcus@synchromedia.co.uk>
+ADD mysql_bootstrap.sh /tmp/mysql_bootstrap.sh
 
-ENV DEBIAN_FRONTEND noninteractive
-
-# Update everything
-RUN apt-get update -qq && apt-get upgrade -y -q && apt-get dist-upgrade -y -q
-
-# Add Percona repo
-RUN apt-key adv --keyserver keys.gnupg.net --recv-keys 1C4CBDCDCD2EFD2A
-#RUN gpg -a --export CD2EFD2A | apt-key add -
-RUN echo "deb http://repo.percona.com/apt `lsb_release -cs` main" > /etc/apt/sources.list.d/percona.list && \
-    echo "deb-src http://repo.percona.com/apt `lsb_release -cs` main" >> /etc/apt/sources.list.d/percona.list
-RUN apt-get update -qq
-
-# Install Percona Server and xtrabackup
-RUN apt-get install -y -qq percona-server-5.6 xtrabackup
-
-# Clean up
-RUN rm -rf /var/lib/apt/lists/*
-
-# Set up MySQL
-RUN sed -i 's/^\(bind-address\s.*\)/# \1/' /etc/mysql/my.cnf && \
-  sed -i 's/^\(log_error\s.*\)/# \1/' /etc/mysql/my.cnf && \
-  echo "mysqld_safe &" > /tmp/config && \
-  echo "sleep 5" >> /tmp/config && \
-  echo "mysql -e 'GRANT ALL PRIVILEGES ON *.* TO \"root\"@\"%\" WITH GRANT OPTION;'" >> /tmp/config && \
-  bash /tmp/config && \
-  rm -f /tmp/config
+RUN apt-key adv --keyserver keys.gnupg.net --recv-keys 1C4CBDCDCD2EFD2A && \
+    echo "deb http://repo.percona.com/apt `lsb_release -cs` main" > /etc/apt/sources.list.d/percona.list && \
+    echo "deb-src http://repo.percona.com/apt `lsb_release -cs` main" >> /etc/apt/sources.list.d/percona.list && \
+    apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq percona-server-5.6 && \
+    rm -rf /var/lib/apt/lists/* && \
+    sed -i 's/^\(bind-address\s.*\)/# \1/' /etc/mysql/my.cnf && \
+    sed -i 's/^\(log_error\s.*\)/# \1/' /etc/mysql/my.cnf && \
+    bash /tmp/mysql_bootstrap.sh && \
+    rm -f /tmp/mysql_bootstrap.sh
 
 # Define mountable directories.
 VOLUME ["/data", "/etc/mysql", "/var/lib/mysql"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,34 +7,18 @@
 # Pull base image.
 FROM dockerfile/ubuntu
 
-MAINTAINER Marcus Bointon <marcus@synchromedia.co.uk>
+ADD mysql_bootstrap.sh
 
-ENV DEBIAN_FRONTEND noninteractive
-
-# Update everything
-RUN apt-get update -qq && apt-get upgrade -y -q && apt-get dist-upgrade -y -q
-
-# Add Percona repo
-RUN apt-key adv --keyserver keys.gnupg.net --recv-keys 1C4CBDCDCD2EFD2A
-#RUN gpg -a --export CD2EFD2A | apt-key add -
-RUN echo "deb http://repo.percona.com/apt `lsb_release -cs` main" > /etc/apt/sources.list.d/percona.list && \
-    echo "deb-src http://repo.percona.com/apt `lsb_release -cs` main" >> /etc/apt/sources.list.d/percona.list
-RUN apt-get update -qq
-
-# Install Percona Server and xtrabackup
-RUN apt-get install -y -qq percona-server-5.6 xtrabackup
-
-# Clean up
-RUN rm -rf /var/lib/apt/lists/*
-
-# Set up MySQL
-RUN sed -i 's/^\(bind-address\s.*\)/# \1/' /etc/mysql/my.cnf && \
-  sed -i 's/^\(log_error\s.*\)/# \1/' /etc/mysql/my.cnf && \
-  echo "mysqld_safe &" > /tmp/config && \
-  echo "sleep 5" >> /tmp/config && \
-  echo "mysql -e 'GRANT ALL PRIVILEGES ON *.* TO \"root\"@\"%\" WITH GRANT OPTION;'" >> /tmp/config && \
-  bash /tmp/config && \
-  rm -f /tmp/config
+RUN apt-key adv --keyserver keys.gnupg.net --recv-keys 1C4CBDCDCD2EFD2A && \
+    echo "deb http://repo.percona.com/apt `lsb_release -cs` main" > /etc/apt/sources.list.d/percona.list && \
+    echo "deb-src http://repo.percona.com/apt `lsb_release -cs` main" >> /etc/apt/sources.list.d/percona.list && \
+    apt-get update -qq && \
+    apt-get install -y -qq percona-server-5.6 && \
+    rm -rf /var/lib/apt/lists/* && \
+    sed -i 's/^\(bind-address\s.*\)/# \1/' /etc/mysql/my.cnf && \
+    sed -i 's/^\(log_error\s.*\)/# \1/' /etc/mysql/my.cnf && \
+    bash mysql_bootstrap.sh && \
+    rm -f mysql_bootstrap.sh
 
 # Define mountable directories.
 VOLUME ["/data", "/etc/mysql", "/var/lib/mysql"]

--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 
 This repository contains a **Dockerfile** for [Percona Server](http://www.percona.com/software/percona-server) for [Docker](https://www.docker.com/)'s [automated build](https://registry.hub.docker.com/u/dockerfile/percona/) published to the public [Docker Hub Registry](https://registry.hub.docker.com/).
 
-The installer also includes the [xtrabackup](http://www.percona.com/software/percona-xtrabackup) backup package.
-
 
 ### Dependencies
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 This repository contains **Dockerfile** of [Percona Server](http://www.percona.com/software/percona-server) for [Docker](https://www.docker.com/)'s [automated build](https://registry.hub.docker.com/u/dockerfile/percona/) published to the public [Docker Hub Registry](https://registry.hub.docker.com/).
 
+The installer also includes the [xtrabackup](http://www.percona.com/software/percona-xtrabackup) backup package.
+
 
 ### Dependencies
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Percona Server Dockerfile
 
 
-This repository contains **Dockerfile** of [Percona Server](http://www.percona.com/software/percona-server) for [Docker](https://www.docker.com/)'s [automated build](https://registry.hub.docker.com/u/dockerfile/percona/) published to the public [Docker Hub Registry](https://registry.hub.docker.com/).
+This repository contains a **Dockerfile** for [Percona Server](http://www.percona.com/software/percona-server) for [Docker](https://www.docker.com/)'s [automated build](https://registry.hub.docker.com/u/dockerfile/percona/) published to the public [Docker Hub Registry](https://registry.hub.docker.com/).
 
 The installer also includes the [xtrabackup](http://www.percona.com/software/percona-xtrabackup) backup package.
 

--- a/mysql_bootstrap.sh
+++ b/mysql_bootstrap.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 mysqld_safe &
 # Wait until MySQL is up
-while ! mysqladmin ping; do
-    sleep 1
-done
-mysql -e 'GRANT ALL PRIVILEGES ON *.* TO \"root\"@\"%\" WITH GRANT OPTION;'
+mysqladmin --silent --wait=20 ping || exit 1
+mysql -e 'GRANT ALL PRIVILEGES ON *.* TO "root"@"%" WITH GRANT OPTION;'

--- a/mysql_bootstrap.sh
+++ b/mysql_bootstrap.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+mysqld_safe &
+# Wait until MySQL is up
+mysqladmin --silent --wait=20 ping || exit 1
+mysql -e 'GRANT ALL PRIVILEGES ON *.* TO "root"@"%" WITH GRANT OPTION;'

--- a/mysql_bootstrap.sh
+++ b/mysql_bootstrap.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 mysqld_safe &
 # Wait until MySQL is up
-wait $!
+while ! mysqladmin ping; do
+    sleep 1
+done
 mysql -e 'GRANT ALL PRIVILEGES ON *.* TO \"root\"@\"%\" WITH GRANT OPTION;'

--- a/mysql_bootstrap.sh
+++ b/mysql_bootstrap.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+mysqld_safe &
+# Wait until MySQL is up
+wait $!
+mysql -e 'GRANT ALL PRIVILEGES ON *.* TO \"root\"@\"%\" WITH GRANT OPTION;'


### PR DESCRIPTION
Dockerfile rearranged as requested.

I needed to set `DEBIAN_FRONTEND=noninteractive`, but only on the install step, not as an `ENV`; otherwise it throws lots of errors.

I've come up with a 1-line mysql detection method that's both faster and more reliable than sleep, and causes an immediate fail if it doesn't work, rather than waiting for the next command to fail.

I have kept the bootstrap script in an external file as (since this is intended to be an easy base to modify) it's much less hassle to extend that than to deal with all the escaping and quoting issues of doing the same thing in the Dockerfile In fact it would be better to move the sed calls in there too so everything is in one place. The `ADD` of the file does create an image state, but it's deleted automatically.
