### PR TITLE
Make waiting for mysql to be up more reliable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN \
   sed -i 's/^\(bind-address\s.*\)/# \1/' /etc/mysql/my.cnf && \
   sed -i 's/^\(log_error\s.*\)/# \1/' /etc/mysql/my.cnf && \
   echo "mysqld_safe &" > /tmp/config && \
-  echo "sleep 5" >> /tmp/config && \
+  echo "mysqladmin --silent --wait=30 ping || exit 1" >> /tmp/config && \
   echo "mysql -e 'GRANT ALL PRIVILEGES ON *.* TO \"root\"@\"%\" WITH GRANT OPTION;'" >> /tmp/config && \
   bash /tmp/config && \
   rm -f /tmp/config


### PR DESCRIPTION
The current Dockerfile fails for me because it doesn't wait until mysql is up, so I changed it to actually wait until it's responding, rather than a random amount of time. The `mysqladmin ping` command is specifically intended to do this, and contains a built-in retry mechanism, so no messy loops, variables or conditions are needed. If that fails, it issues an `exit 1` in order to fail immediately, rather than waiting for subsequent commands (possibly added by others in future forks) to fail as a consequence.
